### PR TITLE
Add filename_proc option to Factory generator

### DIFF
--- a/features/fixture_replacement_config.feature
+++ b/features/fixture_replacement_config.feature
@@ -115,3 +115,18 @@ Feature:
       | spec/factories/users_suffix.rb |
     Then the following files should not exist:
       | spec/factories/users.rb |
+
+  Scenario: Use a filename_proc with the Factory Girl generator
+    When I add "rspec-rails" as a dependency
+    When I configure the factories as:
+      """
+      config.generators do |g|
+        g.factory_girl filename_proc: Proc.new { |tb| "prefix_#{tb.singularize}_suffix" }
+      end
+      """
+    And I run `bundle install` with a clean environment
+    And I run `bundle exec rails generate model User name:string` with a clean environment
+    Then the following files should exist:
+      | spec/factories/prefix_user_suffix.rb |
+    Then the following files should not exist:
+      | spec/factories/users.rb |

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -6,19 +6,6 @@ When /^I add "([^"]+)" as a dependency$/ do |gem_name|
   append_to_file('Gemfile', %{gem "#{gem_name}"\n})
 end
 
-When /^I set the FactoryGirl :suffix option to "([^"]+)"$/ do |suffix|
-  append_to_file('config/application.rb', <<-RUBY)
-    module Testapp
-      class Application < Rails::Application
-        config.generators do |g|
-          g.fixture_replacement :factory_girl, :suffix => '#{suffix}'
-        end
-      end
-    end
-  RUBY
-
-end
-
 When /^I print out "([^"]*)"$/ do |path|
   in_current_dir do
     File.open(path, 'r') do |f|

--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -48,7 +48,6 @@ module FactoryGirl
       end
 
       def create_factory_file
-        filename = [table_name, filename_suffix].compact.join('_')
         file = File.join(options[:dir], "#{filename}.rb")
         create_file(file, single_file_factory_definition)
       end
@@ -73,6 +72,14 @@ RUBY
         attributes.map do |attribute|
           "#{attribute.name} #{attribute.default.inspect}"
         end.join("\n")
+      end
+
+      def filename
+        if factory_girl_options[:filename_proc].present?
+          factory_girl_options[:filename_proc].call(table_name)
+        else
+          [table_name, filename_suffix].compact.join('_')
+        end
       end
 
       def filename_suffix


### PR DESCRIPTION
Add a filename_proc option to the Factory generator for better control over the generated factory filename.

Main motivation for this pull request is the ability to use the singularized model_name in the factory filename. For the model Book I want to be able to call the factory book_factory.rb, while with the suffix option only books_factory.rb can be achieved. I believe the latter filename is not semantically correct, because the file defines the data for a single book.

With the filename_proc option people could of course also add prefixes or suffixes to the filename. Therefore this option could potentially replace the suffix option, although it is also possible to support them both for legacy reasons.