### PR TITLE
Change FactoryGirl::Generators::Base#explicit_class_option to output 1.9 Hashes

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -15,7 +15,7 @@ Feature:
     Then the output should contain "test/factories/users.rb"
     And the output should contain "test/factories/namespaced_users.rb"
     And the file "test/factories/users.rb" should contain "factory :user do"
-    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, :class => 'Namespaced::User' do"
+    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
 
   Scenario: The factory_girl_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory
     When I run `bundle install` with a clean environment

--- a/lib/generators/factory_girl.rb
+++ b/lib/generators/factory_girl.rb
@@ -8,7 +8,7 @@ module FactoryGirl
       end
 
       def explicit_class_option
-        ", :class => '#{class_name}'" unless class_name == singular_table_name.camelize
+        ", class: '#{class_name}'" unless class_name == singular_table_name.camelize
       end
     end
   end


### PR DESCRIPTION
This changes the generator to use the 1.9-style Hash syntax for the `class` option. So, where previously the generator would output:

```ruby
FactoryGirl.define do
  factory :buttery_biscuit_base, :class => 'Buttery::BiscuitBase' do
    #...
  end
end
```

it will now output:

```ruby
FactoryGirl.define do
  factory :buttery_biscuit_base, class: 'Buttery::BiscuitBase' do
    #...
  end
end
```

I totally understand this is a very minor change and is ultimately down to personal preference - but it is something I would like :). FactoryGirl requires Ruby > 1.9 (https://github.com/thoughtbot/factory_girl/blob/master/factory_girl.gemspec#L17) so this shouldn't cause any issues in practice. 