### PR TITLE
fix indent of generated factory file

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -10,11 +10,20 @@ Feature:
 
   Scenario: The factory_girl_rails generators create a factory file for each model if there is not a factories.rb file
     When I run `bundle install` with a clean environment
-    And I run `bundle exec rails generate model User name:string` with a clean environment
+    And I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     And I run `bundle exec rails generate model Namespaced::User name:string` with a clean environment
     Then the output should contain "test/factories/users.rb"
     And the output should contain "test/factories/namespaced_users.rb"
-    And the file "test/factories/users.rb" should contain "factory :user do"
+    And the file "test/factories/users.rb" should contain exactly:
+      """
+      FactoryGirl.define do
+        factory :user do
+          name "MyString"
+          age 1
+        end
+      end
+
+      """
     And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, :class => 'Namespaced::User' do"
 
   Scenario: The factory_girl_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory

--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -49,7 +49,7 @@ module FactoryGirl
       def factory_definition
 <<-RUBY
   factory :#{singular_table_name}#{explicit_class_option} do
-    #{factory_attributes}
+#{factory_attributes.gsub(/^/, "    ")}
   end
 RUBY
       end
@@ -57,7 +57,7 @@ RUBY
       def single_file_factory_definition
 <<-RUBY
 FactoryGirl.define do
-#{factory_definition}
+#{factory_definition.chomp}
 end
 RUBY
       end


### PR DESCRIPTION
With a command `rails g factory_girl:model foo bar baz`, the output is:
```
FactoryGirl.define do
  factory :foo do
    bar "MyString"
baz "MyString"
  end

end
```

This PR fixes the output:
```
FactoryGirl.define do
  factory :foo do
    bar "MyString"
    baz "MyString"
  end

end
```
