### PR TITLE
Updated travis.yml with ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
   - jruby-19mode
 jdk:
   - openjdk6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
-    cucumber (1.3.15)
+    cucumber (1.3.18)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)


### PR DESCRIPTION
- FIX# Build error on ruby 2.2

When I am running features I am getting following error: 

```
~/work/factory_girl_rails (ruby-2.2) $be rake cucumber
/home/siva/.rvm/rubies/ruby-2.2.0/bin/ruby -S bundle exec cucumber --format progress
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/step.rb:80: warning: circular argument reference - name
undefined method `unpack' for nil:NilClass (NoMethodError)
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/step.rb:81:in `text_length'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/step_collection.rb:62:in `block in max_line_length'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/step_collection.rb:62:in `map'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/step_collection.rb:62:in `max_line_length'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/has_steps.rb:53:in `max_line_length'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/has_steps.rb:49:in `source_indent'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/background.rb:40:in `accept'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:64:in `block in visit_background'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:63:in `visit_background'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/feature.rb:36:in `accept'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:27:in `block in visit_feature'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:26:in `visit_feature'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/features.rb:28:in `block in accept'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/features.rb:17:in `each'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/features.rb:17:in `each'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/features.rb:27:in `accept'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:21:in `block in visit_features'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:170:in `broadcast'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/ast/tree_walker.rb:20:in `visit_features'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/runtime.rb:49:in `run!'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/lib/cucumber/cli/main.rb:47:in `execute!'
/home/siva/.rvm/gems/ruby-2.2.0/gems/cucumber-1.3.15/bin/cucumber:13:in `<top (required)>'
/home/siva/.rvm/gems/ruby-2.2.0/bin/cucumber:23:in `load'
/home/siva/.rvm/gems/ruby-2.2.0/bin/cucumber:23:in `<main>'
/home/siva/.rvm/gems/ruby-2.2.0/bin/ruby_executable_hooks:15:in `eval'
/home/siva/.rvm/gems/ruby-2.2.0/bin/ruby_executable_hooks:15:in `<main>'
```
