### PR TITLE
chore(gemspec): remove bin/setup from gem

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.license       = "MIT"
 


### PR DESCRIPTION
Remove bin/setup from gem, this is not for gem users,
but for gem developers.

factory_girl_rails v4.5.0 includes bin/setup as executable on gem,
so I can exec `setup` anywhere (and raise error).

```
$ setup
/Users/sane/.anyenv/envs/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/factory_girl_rails-4.5.0/bin/setup:6:in
`<top (required)>': undefined local variable or method `e' for
main:Object (NameError)
        from
/Users/sane/.anyenv/envs/rbenv/versions/2.2.0/bin/setup:23:in `load'
        from
/Users/sane/.anyenv/envs/rbenv/versions/2.2.0/bin/setup:23:in `<main>'
```