### PR TITLE
Remove `setup` from gem's executables list

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.license       = "MIT"
 


### PR DESCRIPTION
bin/setup script should be used in development. So `factory-girl-rails` should not declare `setup` as a gem executable file