### PR TITLE
Fix when use fixture_replacement with suffix option.

### DIFF
--- a/features/fixture_replacement_config.feature
+++ b/features/fixture_replacement_config.feature
@@ -32,6 +32,23 @@ Feature:
     And the following files should not exist:
       | spec/fixtures/users.yml |
 
+  Scenario: Using Factory Girl and Factory Girl Rails with RSpec and suffix configuration should generate a factory file with suffix
+    When I add "rspec-rails" as a dependency
+    And I configure the factories as:
+      """
+      config.generators do |g|
+        g.test_framework :rspec, fixture: true
+        g.fixture_replacement :factory_girl, suffix: 'factory'
+      end
+      """
+    And I run `bundle install` with a clean environment
+    Then the output should contain "rspec-rails"
+    And I run `bundle exec rails generate model User name:string` with a clean environment
+    Then the following files should exist:
+      | spec/factories/users_factory.rb |
+    And the following files should not exist:
+      | spec/fixtures/users.yml |
+
   Scenario: Using Factory Girl and Factory Girl Rails does not override a manually-configured factories directory using RSpec
     When I add "rspec-rails" as a dependency
     And I configure the factories directory as "custom/dir"

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -15,7 +15,7 @@ Feature:
     Then the output should contain "test/factories/users.rb"
     And the output should contain "test/factories/namespaced_users.rb"
     And the file "test/factories/users.rb" should contain "factory :user do"
-    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, :class => 'Namespaced::User' do"
+    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
 
   Scenario: The factory_girl_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory
     When I run `bundle install` with a clean environment

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -64,7 +64,7 @@ Feature: automatically load step definitions
     When I write to "lib/some_railtie/factories.rb" with:
       """
       FactoryGirl.define do
-        factory :factory_from_some_railtie, :class => 'User' do
+        factory :factory_from_some_railtie, class: 'User' do
           name 'Artem'
         end
       end

--- a/lib/generators/factory_girl.rb
+++ b/lib/generators/factory_girl.rb
@@ -8,7 +8,7 @@ module FactoryGirl
       end
 
       def explicit_class_option
-        ", :class => '#{class_name}'" unless class_name == singular_table_name.camelize
+        ", class: '#{ class_name }'" unless class_name == singular_table_name.camelize
       end
     end
   end

--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -18,6 +18,13 @@ module FactoryGirl
         desc: "The directory or file root where factories belong"
       )
 
+      class_option(
+        :suffix,
+        type: :string,
+        default: nil,
+        desc: "Suffix to add factory file"
+      )
+
       def create_fixture_file
         if File.exist?(factories_file)
           insert_factory_into_existing_file
@@ -69,7 +76,7 @@ RUBY
       end
 
       def filename_suffix
-        factory_girl_options[:suffix]
+        factory_girl_options[:suffix] || options[:suffix]
       end
 
       def factory_girl_options


### PR DESCRIPTION
Fix #113 and use new hash syntax on generator.

```ruby
FactoryGirl.define do
  factory :user, class: 'User' do
    name "Jhon"
  end
end
```
