### PR TITLE
Do not include any executable since bin/setup needed only in development

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
+  s.executables   = []
   s.license       = "MIT"
 
   s.add_runtime_dependency('railties', '>= 3.0.0')


### PR DESCRIPTION
After installing factory_girl_rails gem there is a `setup` executable with following:

```ruby
#!/usr/bin/env ruby
#
# This file was generated by RubyGems.
#
# The application 'factory_girl_rails' is installed as part of a gem, and
# this file is here to facilitate running it.
#

require 'rubygems'

version = ">= 0"

if ARGV.first
  str = ARGV.first
  str = str.dup.force_encoding("BINARY") if str.respond_to? :force_encoding
  if str =~ /\A_(.*)_\z/ and Gem::Version.correct?($1) then
    version = $1
    ARGV.shift
  end
end

gem 'factory_girl_rails', version
load Gem.bin_path('factory_girl_rails', 'setup', version)
```
There should not been such executable.