### PR TITLE
Changed how factory_attributes is indented

### DIFF
--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -4,6 +4,9 @@ require 'factory_girl_rails'
 module FactoryGirl
   module Generators
     class ModelGenerator < Base
+      # Indentation for attributes of 4 spaces
+      INDENTATION = "    ".freeze
+
       argument(
         :attributes,
         type: :array,
@@ -55,7 +58,7 @@ module FactoryGirl
       def factory_definition
 <<-RUBY
   factory :#{singular_table_name}#{explicit_class_option} do
-#{factory_attributes.gsub(/^/, "    ")}
+#{factory_attributes}
   end
 RUBY
       end
@@ -70,7 +73,7 @@ RUBY
 
       def factory_attributes
         attributes.map do |attribute|
-          "#{attribute.name} #{attribute.default.inspect}"
+          "#{INDENTATION}#{attribute.name} #{attribute.default.inspect}"
         end.join("\n")
       end
 


### PR DESCRIPTION
Why am I doing this?
When I generate a new factory file, I expect to see consistent indentation of
4 spaces. However, I am seeing only the first attribute indented, while the rest
have zero spaces.

Example:

```rb
FactoryGirl.define do
  factory :event do
    user nil
action "MyString"
data ""
  end

end
```

**How am I fixing this?**
Instead of gsubbing for the caret operator, I am putting the indentation straight
into the #factory_attributes method.

**What are the side effects?**
If #factory_attributes is depended on by plugins, this may be a breaking change (though
it's a private method)

**How else could you do this?**
I would love to know why the caret operator is not operating consistently and fix the root
cause instead.