### PR TITLE
Update Gemspec file to not use `git ls-files`

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
     factory_girl and rails 3 (currently just automatic factory definition
     loading)}
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   s.require_paths = ["lib"]
   s.executables   = []
   s.license       = "MIT"


### PR DESCRIPTION
The gem is dependent on Git (factory_girl_rails.gemspec uses git ls-files).
Some prod environments do not have git and if you try adding a gem through
git or path option in bundler, 'git ls-files' in the .gemspec fails.
Instead of using git, we could use pure Ruby code to list the gem files.

Fixes #177.