### PR TITLE
Add $ to command line instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Github: http://github.com/thoughtbot/factory_girl_rails
 
 Gem:
 
-    gem install factory_girl_rails
+    $ gem install factory_girl_rails
 
 ## Configuration
 


### PR DESCRIPTION
I've added $ mark into console instruction.
$ marks help us to understand which is console and which is Ruby's source code.
It's the same as [Rails README.md](https://github.com/rails/rails/blob/master/README.md)

**Before:**
```console
gem install factory_girl_rails
```
```ruby
gem 'factory_girl_rails'
```

**After:**
```console
$ gem install factory_girl_rails
```
```ruby
gem 'factory_girl_rails'
```

Thank you.