### PR TITLE
Updates ReadMe to recommend environments for gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Gem:
 Add `factory_girl_rails` to your Gemfile:
 
 ```ruby
-gem 'factory_girl_rails'
+group :development, :test do
+  gem 'factory_girl_rails'
+end
 ```
 
 Generators for factories will automatically substitute fixture (and maybe any other


### PR DESCRIPTION
Recommends adding  `factory_girl_rails` to both your `:test` and `:development` groups so generators will work in development. As per issue  https://github.com/thoughtbot/factory_girl_rails/issues/88